### PR TITLE
Subsitute custom data structure by geopandas df

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
   - pip install flake8 sphinx sphinx-rtd-theme
 script:
   - flake8 s5a
-  - python -c 'import s5a; s=s5a.Scan(".testdata/test.nc"); exit(s.len() - 226)'
+  - python -c 'import s5a; s=s5a.load_ncfile(".testdata/test.nc"); exit(s.shape[0] - 226)'
   - make -C docs clean html

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ dist: bionic
 python:
   - 3.6
   - 3.7
+  - 3.8
 
 install:
   - pip install -r requirements.txt
@@ -13,3 +14,15 @@ install:
 script:
   - flake8 s5a
   - make -C docs clean html
+  - |
+    python -c '
+    import s5a
+    s = s5a.load_ncfile(".testdata/test.nc")
+    s.size == 1130 or exit(1)
+    s = s5a.filter_by_quality(s, 0)
+    s.size == 1130 or exit(1)
+    s = s5a.filter_by_quality(s, 0.5)
+    s.size == 900 or exit(1)
+    s = s5a.filter_by_quality(s)
+    s.size == 900 or exit(1)
+    '

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ install:
   - pip install flake8 sphinx sphinx-rtd-theme
 script:
   - flake8 s5a
-  - python -c 'import s5a; s=s5a.load_ncfile(".testdata/test.nc"); exit(s.shape[0] - 226)'
   - make -C docs clean html

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ dist: bionic
 python:
   - 3.6
   - 3.7
-  - 3.8
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ install:
   - pip install flake8 sphinx sphinx-rtd-theme
 script:
   - flake8 s5a
-  - python -c 'import s5a; s=s5a.Scan(".testdata/test.nc"); exit(s.len() - 430)'
+  - python -c 'import s5a; s=s5a.Scan(".testdata/test.nc"); exit(s.len() - 226)'
   - make -C docs clean html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,4 +52,4 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
 
-autodoc_mock_imports = ["netCDF4", "numpy"]
+autodoc_mock_imports = ["netCDF4", "geopandas"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,4 +52,4 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
 
-autodoc_mock_imports = ["netCDF4", "geopandas"]
+autodoc_mock_imports = ["netCDF4", "numpy", "pandas"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 netCDF4>=1.5.2
 numpy>=1.10.0
+geopandas>=0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 netCDF4>=1.5.2
 numpy>=1.10.0
+pandas>=0.25.3
 geopandas>=0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 netCDF4>=1.5.2
 numpy>=1.10.0
 pandas>=0.25.3
-geopandas>=0.6.2

--- a/s5a/__init__.py
+++ b/s5a/__init__.py
@@ -55,7 +55,7 @@ def load_ncfile(ncfile):
             'timestamp': timestamps,
             'quality': quality[mask],
             'value': data[mask]
-        },geometry=geopandas.points_from_xy(
+        }, geometry=geopandas.points_from_xy(
             longitude[mask],
             latitude[mask])
         )

--- a/s5a/__init__.py
+++ b/s5a/__init__.py
@@ -61,7 +61,7 @@ def load_ncfile(ncfile):
         )
 
 
-def filter_data(dataframe, minimal_quality=0.5):
+def filter_by_quality(dataframe, minimal_quality=0.5):
     """Filter points by quality.
 
     :param dataframe: a dataframe as returned from load_ncfile()

--- a/s5a/__init__.py
+++ b/s5a/__init__.py
@@ -62,28 +62,16 @@ def load_ncfile(ncfile):
     )
 
 
-class Scan():
-    """Object to hold arrays from an nc file.
+def filter_data(dataframe, minimal_quality=0.7):
+    """Filter points of the Scan by quality.
+
+    :param dataframe: a dataframe as returned from load_ncfile()
+    :type dataframe: geopandas.GeoDataFrame
+    :param minimal_quality: Minimal allowed quality,
+        has to be in the range of 0.0 - 1.0
+    :type minimal_quality: float
+    :return: the dataframe filtered by the specified value
+    :rtype: geopandas.GeoDataFrame
     """
-
-    def __init__(self, filepath):
-        self.filepath = filepath
-        self.data = load_ncfile(filepath)
-
-    def filter_by_quality(self, minimal_quality):
-        """Filter points of the Scan by quality.
-
-        :param minimal_quality: Minimal allowed quality,
-            has to be in the range of 0.0 - 1.0
-        :type minimal_quality: float
-        """
-        has_quality = self.data.quality >= minimal_quality
-        self.data = self.data[has_quality]
-
-    def len(self):
-        """Get number of points in Scan.
-
-        :return: Number of data points
-        :rtype: int
-        """
-        return self.data.shape[0]
+    has_quality = dataframe.quality >= minimal_quality
+    return dataframe[has_quality]

--- a/s5a/__init__.py
+++ b/s5a/__init__.py
@@ -43,32 +43,32 @@ def load_ncfile(ncfile):
     time_reference = meta_data['time_reference_seconds_since_1970']
 
     # convert deltatime to timestamps
+    # add (milli-)seconds since 1970
+    deltatime = numpy.add(deltatime, time_reference * 1000)
     deltatime_arr = numpy.repeat(
         deltatime, pixel_per_line).reshape(n_lines, -1)
     deltatime_arr = deltatime_arr[mask]  # filter for missing data
-    # add (milli-)seconds since 1970
-    deltatime_arr = numpy.add(deltatime_arr, time_reference * 1000)
     timestamps = pandas.to_datetime(deltatime_arr, utc=True, unit='ms')
 
     # convert data to geodataframe
     return geopandas.GeoDataFrame({
-        'timestamp': timestamps,
-        'quality': quality[mask],
-        'data': data[mask]
-    },
-        geometry=geopandas.points_from_xy(
+            'timestamp': timestamps,
+            'quality': quality[mask],
+            'value': data[mask]
+        },geometry=geopandas.points_from_xy(
             longitude[mask],
             latitude[mask])
-    )
+        )
 
 
-def filter_data(dataframe, minimal_quality=0.7):
-    """Filter points of the Scan by quality.
+def filter_data(dataframe, minimal_quality=0.5):
+    """Filter points by quality.
 
     :param dataframe: a dataframe as returned from load_ncfile()
     :type dataframe: geopandas.GeoDataFrame
     :param minimal_quality: Minimal allowed quality,
-        has to be in the range of 0.0 - 1.0
+        has to be in the range of 0.0 - 1.0 and defaults to
+        0.5 as suggested by the ESA product manual
     :type minimal_quality: float
     :return: the dataframe filtered by the specified value
     :rtype: geopandas.GeoDataFrame

--- a/s5a/__init__.py
+++ b/s5a/__init__.py
@@ -6,7 +6,6 @@
 """
 import logging
 
-import geopandas
 import netCDF4
 import numpy
 import pandas
@@ -16,13 +15,13 @@ logger = logging.getLogger(__name__)
 
 
 def load_ncfile(ncfile):
-    """Load a ncfile into a geopandas dataframe
+    """Load a ncfile into a pandas dataframe
 
     :param ncfile: path of the file to be read
     :type ncfile: string
-    :return: a geopandas geodataframe containing
+    :return: a pandas dataframe containing
         the groundpixel information as points
-    :rtype: geopandas.GeoDataFrame
+    :rtype: pandas.DataFrame
     """
 
     # read in data
@@ -51,27 +50,26 @@ def load_ncfile(ncfile):
     timestamps = pandas.to_datetime(deltatime_arr, utc=True, unit='ms')
 
     # convert data to geodataframe
-    return geopandas.GeoDataFrame({
+    return pandas.DataFrame({
             'timestamp': timestamps,
             'quality': quality[mask],
-            'value': data[mask]
-        }, geometry=geopandas.points_from_xy(
-            longitude[mask],
-            latitude[mask])
-        )
+            'value': data[mask],
+            'longitude': longitude[mask],
+            'latitude': latitude[mask]
+        })
 
 
 def filter_by_quality(dataframe, minimal_quality=0.5):
     """Filter points by quality.
 
     :param dataframe: a dataframe as returned from load_ncfile()
-    :type dataframe: geopandas.GeoDataFrame
+    :type dataframe: pandas.DataFrame
     :param minimal_quality: Minimal allowed quality,
         has to be in the range of 0.0 - 1.0 and defaults to
         0.5 as suggested by the ESA product manual
     :type minimal_quality: float
     :return: the dataframe filtered by the specified value
-    :rtype: geopandas.GeoDataFrame
+    :rtype: pandas.DataFrame
     """
     has_quality = dataframe.quality >= minimal_quality
     return dataframe[has_quality]

--- a/s5a/__init__.py
+++ b/s5a/__init__.py
@@ -16,6 +16,14 @@ logger = logging.getLogger(__name__)
 
 
 def load_ncfile(ncfile):
+    """Load a ncfile into a geopandas dataframe
+
+    :param ncfile: path of the file to be read
+    :type ncfile: string
+    :return: a geopandas geodataframe containing
+        the groundpixel information as points
+    :rtype: geopandas.GeoDataFrame
+    """
 
     # read in data
     with netCDF4.Dataset(ncfile, 'r') as f:
@@ -57,6 +65,7 @@ def load_ncfile(ncfile):
 class Scan():
     """Object to hold arrays from an nc file.
     """
+
     def __init__(self, filepath):
         self.filepath = filepath
         self.data = load_ncfile(filepath)
@@ -64,8 +73,9 @@ class Scan():
     def filter_by_quality(self, minimal_quality):
         """Filter points of the Scan by quality.
 
-        :param minimal_quality: Minimal allowed quality
-        :type minimal_quality: int
+        :param minimal_quality: Minimal allowed quality,
+            has to be in the range of 0.0 - 1.0
+        :type minimal_quality: float
         """
         has_quality = self.data.quality >= minimal_quality
         self.data = self.data[has_quality]
@@ -73,7 +83,7 @@ class Scan():
     def len(self):
         """Get number of points in Scan.
 
-        :return: Number of points
+        :return: Number of data points
         :rtype: int
         """
         return self.data.shape[0]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(filename):
 
 setup(
     name='s5a',
-    version='0.1',
+    version='0.2',
     description='Sentinel-5 Algorithms',
     author='Emissions API Developers',
     license='MIT',


### PR DESCRIPTION
I got rid of the custom point format and switched to ~geopandas~ pandas for the internal data representation.

Closes #13 

It is about twice as fast as the original implementation (see image below). I hope that this does not cause problems when writing to the database:
![scan_vs_load](https://user-images.githubusercontent.com/39943803/69575639-f1a2a500-0fca-11ea-85d6-e4576950e88c.png)

It breaks emissions-api in the sense that I took the decision to leave the quality values *as is* (which is a float in the range of 0.0 - 1.0) and not multiply them by 100. If I understand the [Product Readme](https://sentinel.esa.int/documents/247904/3541451/Sentinel-5P-Carbon-Monoxide-Level-2-Product-Readme-File) (page 6) correctly, these values are also rather intended by ESA as categories than actual values that can fill the whole range. Therefore, I would rather leave them in their original format, for standardization reasons.