### PR TITLE
Remove Version from Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-netCDF4>=1.5.2
-numpy>=1.10.0
-pandas>=0.25.3
+netCDF4
+numpy
+pandas


### PR DESCRIPTION
This way we have less depenceny problems. We do not know what version are
working, so the restriction is kind of pointless.